### PR TITLE
Resolve Inspection Command Bug

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -17,15 +17,18 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_ARCHIVED_PERSON_DISPLAYED_INDEX = "The person index provided refers to "
-            + "an archived person." + "\nUnarchive the person to continue";
+    public static final String MESSAGE_ARCHIVED_PERSON_DISPLAYED_INDEX =
+            "The person index provided refers to an archived person.\n"
+            + "Unarchive the person to continue";
     public static final String MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX = "The delivery index provided is invalid";
-    public static final String MESSAGE_ARCHIVED_DELIVERY_DISPLAYED_INDEX = "The delivery index provided refers to "
-            + "an archived delivery." + "\n Unarchive the delivery to continue.";
+    public static final String MESSAGE_ARCHIVED_DELIVERY_DISPLAYED_INDEX =
+            "The delivery index provided refers to an archived delivery.\n"
+            + "Unarchive the delivery to continue.";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
-
+    public static final String MESSAGE_INVALID_WINDOW = "This command could not be executed in the inspection window.\n"
+            + "Navigate back to the main window to continue.";
     /**
      * Returns an error message indicating the duplicate prefixes.
      */

--- a/src/main/java/seedu/address/logic/commands/InspectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/InspectCommand.java
@@ -7,6 +7,7 @@ import java.util.List;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
@@ -23,6 +24,7 @@ public class InspectCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_INSPECT_SUCCESS = "Inspected person: %1$s";
+    public static final String MESSAGE_INSPECT_INVALID = "Inspected person: %1$s";
     private final Index index;
 
     /**
@@ -44,6 +46,10 @@ public class InspectCommand extends Command {
 
         if (index.getZeroBased() >= model.getFirstArchivedIndex().getZeroBased()) {
             throw new CommandException(Messages.MESSAGE_ARCHIVED_PERSON_DISPLAYED_INDEX);
+        }
+
+        if (AddressBookParser.getInspect()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_WINDOW);
         }
 
         Person personToInspect = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/address/model/person/Archive.java
+++ b/src/main/java/seedu/address/model/person/Archive.java
@@ -41,7 +41,7 @@ public class Archive {
      * Returns true if a given string is a valid archive.
      */
     public boolean isArchived() {
-        return this.value.equals("true");
+        return Boolean.parseBoolean(this.value);
     }
 
 

--- a/src/test/java/seedu/address/logic/commands/InspectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/InspectCommandTest.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+
+import org.junit.jupiter.api.Test;
+public class InspectCommandTest {
+    @Test
+    public void equals() {
+        InspectCommand inspectFirstCommand = new InspectCommand(INDEX_FIRST);
+        InspectCommand inspectSecondCommand = new InspectCommand(INDEX_SECOND);
+
+        // same object -> returns true
+        assertTrue(inspectFirstCommand.equals(inspectFirstCommand));
+
+        // same values -> returns true
+        InspectCommand inspectFirstCommandCopy = new InspectCommand(INDEX_FIRST);
+        assertTrue(inspectFirstCommand.equals(inspectFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(inspectFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(inspectSecondCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(inspectFirstCommand.equals(inspectSecondCommand));
+    }
+}


### PR DESCRIPTION
Resolve the inspection command bug mentioned in #118. 
 
Update: To throw error message
```
This command could not be executed in the inspection window.
Navigate back to the main window to continue.
```
when attempting to use inspect command in the inspection window. 

![image](https://github.com/user-attachments/assets/2eafba33-ef7c-4dd3-9fad-0f6fbc55f678)
