### PR TITLE
Address typo in add command help message within main window 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -38,7 +38,7 @@ public class AddCommand extends Command {
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
-            + PREFIX_ROLE + "ROLE"
+            + PREFIX_ROLE + "ROLE "
             + PREFIX_ADDRESS + "ADDRESS "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "


### PR DESCRIPTION
### Resolve missing space in add command help message mentioned at #127
![image](https://github.com/user-attachments/assets/ffdcb66e-50e3-42bc-9886-146fbe8724dc)