### PR TITLE
Add index for help text

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -16,11 +16,13 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index %1$s provided is invalid";
+    public static final String MESSAGE_INVALID_DUPLICATED_INDEX = "Duplicated index %1$s is not allowed";
     public static final String MESSAGE_ARCHIVED_PERSON_DISPLAYED_INDEX =
             "The person index provided refers to an archived person.\n"
             + "Unarchive the person to continue";
-    public static final String MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX = "The delivery index provided is invalid";
+    public static final String MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX =
+            "The delivery index [%1$s] provided is invalid";
     public static final String MESSAGE_ARCHIVED_DELIVERY_DISPLAYED_INDEX =
             "The delivery index provided refers to an archived delivery.\n"
             + "Unarchive the delivery to continue.";

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -17,12 +17,12 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index %1$s provided is invalid";
+    public static final String MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX =
+            "The delivery index %1$s provided is invalid";
     public static final String MESSAGE_INVALID_DUPLICATED_INDEX = "Duplicated index %1$s is not allowed";
     public static final String MESSAGE_ARCHIVED_PERSON_DISPLAYED_INDEX =
             "The person index provided refers to an archived person.\n"
             + "Unarchive the person to continue";
-    public static final String MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX =
-            "The delivery index [%1$s] provided is invalid";
     public static final String MESSAGE_ARCHIVED_DELIVERY_DISPLAYED_INDEX =
             "The delivery index provided refers to an archived delivery.\n"
             + "Unarchive the delivery to continue.";

--- a/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
@@ -132,12 +132,22 @@ public class ArchiveCommand extends Command {
     private void validateIndexes(int listSize, List<Index> indexList, boolean isDelivery) throws CommandException {
         boolean hasDuplicate = hasDuplicates(indexList);
         for (Index targetIndex : indexList) {
-            if (targetIndex.getZeroBased() >= listSize || hasDuplicate) {
+            if (targetIndex.getZeroBased() >= listSize) {
                 if (isDelivery) {
-                    throw new CommandException(Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX);
+                    throw new CommandException(
+                            String.format(Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX,
+                                    targetIndex.getOneBased()));
                 } else {
-                    throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+                    throw new CommandException(
+                            String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                                    targetIndex.getOneBased()));
                 }
+            }
+
+            if (hasDuplicate) {
+                throw new CommandException(
+                        String.format(Messages.MESSAGE_INVALID_DUPLICATED_INDEX,
+                                targetIndex.getOneBased()));
             }
         }
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -108,12 +108,22 @@ public class DeleteCommand extends Command {
     private void validateIndexes(int listSize, List<Index> indexList, boolean isPersonIndex) throws CommandException {
         boolean duplicate = hasDuplicates(indexList);
         for (Index targetIndex : indexList) {
-            if (targetIndex.getZeroBased() >= listSize || duplicate) {
+            if (targetIndex.getZeroBased() >= listSize) {
                 if (isPersonIndex) {
-                    throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+                    throw new CommandException(
+                            String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                                    targetIndex.getOneBased()));
                 } else {
-                    throw new CommandException(Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX);
+                    throw new CommandException(
+                            String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                                    targetIndex.getOneBased()));
                 }
+            }
+
+            if (duplicate) {
+                throw new CommandException(
+                        String.format(Messages.MESSAGE_INVALID_DUPLICATED_INDEX,
+                                targetIndex.getOneBased()));
             }
         }
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -150,7 +150,8 @@ public class EditCommand extends Command {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(
+                    String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, index.getOneBased()));
         }
 
         if (index.getZeroBased() >= model.getFirstArchivedIndex().getZeroBased()) {

--- a/src/main/java/seedu/address/logic/commands/InspectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/InspectCommand.java
@@ -41,7 +41,8 @@ public class InspectCommand extends Command {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(
+                    String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, index.getOneBased()));
         }
 
         if (index.getZeroBased() >= model.getFirstArchivedIndex().getZeroBased()) {

--- a/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
@@ -222,12 +222,22 @@ public class UnarchiveCommand extends Command {
     private void validateIndexes(int listSize, List<Index> indexList, boolean isDelivery) throws CommandException {
         boolean hasDuplicate = hasDuplicates(indexList);
         for (Index targetIndex : indexList) {
-            if (targetIndex.getZeroBased() >= listSize || hasDuplicate) {
+            if (targetIndex.getZeroBased() >= listSize) {
                 if (isDelivery) {
-                    throw new CommandException(Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX);
+                    throw new CommandException(
+                            String.format(Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX,
+                                    targetIndex.getOneBased()));
                 } else {
-                    throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+                    throw new CommandException(
+                            String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                                    targetIndex.getOneBased()));
                 }
+            }
+
+            if (hasDuplicate) {
+                throw new CommandException(
+                        String.format(Messages.MESSAGE_INVALID_DUPLICATED_INDEX,
+                                targetIndex.getOneBased()));
             }
         }
     }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -61,7 +61,8 @@ public class LogicManagerTest {
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        String expectedErrorMessage = String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, 9);
+        assertCommandException(deleteCommand, expectedErrorMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ArchiveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ArchiveCommandTest.java
@@ -3,7 +3,11 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_DUPLICATED_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_LIST;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_LIST;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD;
@@ -55,6 +59,32 @@ public class ArchiveCommandTest {
         AddressBookParser.setInspect(false);
         assertCommandSuccess(archiveCommand, model, expectedMessage, expectedModel);
     }
+
+    @Test
+    public void execute_outOfBoundIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        List<Index> outOfBoundIndexList = new ArrayList<>();
+        outOfBoundIndexList.add(outOfBoundIndex);
+        ArchiveCommand archiveCommand = new ArchiveCommand(outOfBoundIndexList);
+        String expectedErrorMessage = String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                outOfBoundIndex.getOneBased());
+
+        assertCommandFailure(archiveCommand, model, expectedErrorMessage);
+    }
+
+    @Test
+    public void execute_duplicateIndexUnfilteredList_throwsCommandException() {
+        List<Index> duplicatedList = new ArrayList<>();
+        duplicatedList.add(INDEX_FIRST);
+        duplicatedList.add(INDEX_FIRST);
+        ArchiveCommand archiveCommand = new ArchiveCommand(duplicatedList);
+
+        String expectedErrorMessage = String.format(MESSAGE_INVALID_DUPLICATED_INDEX,
+                INDEX_FIRST.getOneBased());
+
+        assertCommandFailure(archiveCommand, model, expectedErrorMessage);
+    }
+
     //
     //@Test
     //public void execute_validSingleIndexUnfilteredDeliveryList_success() {

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -3,6 +3,8 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_DUPLICATED_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
@@ -75,18 +77,23 @@ public class DeleteCommandTest {
         List<Index> outOfBoundIndexList = new ArrayList<>();
         outOfBoundIndexList.add(outOfBoundIndex);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndexList);
+        String expectedErrorMessage = String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                outOfBoundIndex.getOneBased());
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, expectedErrorMessage);
     }
 
     @Test
     public void execute_duplicateIndexUnfilteredList_throwsCommandException() {
-        List<Index> outOfBoundIndexList = new ArrayList<>();
-        outOfBoundIndexList.add(INDEX_FIRST);
-        outOfBoundIndexList.add(INDEX_FIRST);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndexList);
+        List<Index> duplicatedList = new ArrayList<>();
+        duplicatedList.add(INDEX_FIRST);
+        duplicatedList.add(INDEX_FIRST);
+        DeleteCommand deleteCommand = new DeleteCommand(duplicatedList);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        String expectedErrorMessage = String.format(MESSAGE_INVALID_DUPLICATED_INDEX,
+                INDEX_FIRST.getOneBased());
+
+        assertCommandFailure(deleteCommand, model, expectedErrorMessage);
     }
 
     @Test
@@ -96,8 +103,10 @@ public class DeleteCommandTest {
         outOfBoundIndexList.add(INDEX_FIRST);
         outOfBoundIndexList.add(outOfBoundIndex);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndexList);
+        String expectedErrorMessage = String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                outOfBoundIndex.getOneBased());
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, expectedErrorMessage);
     }
 
     @Test
@@ -131,7 +140,10 @@ public class DeleteCommandTest {
 
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndexList);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        String expectedErrorMessage = String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                outOfBoundIndex.getOneBased());
+
+        assertCommandFailure(deleteCommand, model, expectedErrorMessage);
     }
 
     @Test
@@ -139,15 +151,18 @@ public class DeleteCommandTest {
         showPersonAtIndex(model, INDEX_FIRST);
 
         Index duplicateIndex = INDEX_FIRST;
-        List<Index> outOfBoundIndexList = new ArrayList<>();
-        outOfBoundIndexList.add(INDEX_SECOND);
-        outOfBoundIndexList.add(INDEX_SECOND);
+        List<Index> duplicatedIndexList = new ArrayList<>();
+        duplicatedIndexList.add(INDEX_FIRST);
+        duplicatedIndexList.add(INDEX_FIRST);
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(duplicateIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndexList);
+        DeleteCommand deleteCommand = new DeleteCommand(duplicatedIndexList);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        String expectedErrorMessage = String.format(MESSAGE_INVALID_DUPLICATED_INDEX,
+                duplicateIndex.getOneBased());
+
+        assertCommandFailure(deleteCommand, model, expectedErrorMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -126,7 +126,10 @@ public class EditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        String expectedErrorMessage = String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                outOfBoundIndex.getOneBased());
+
+        assertCommandFailure(editCommand, model, expectedErrorMessage);
     }
 
 
@@ -145,7 +148,10 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        String expectedErrorMessage = String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                outOfBoundIndex.getOneBased());
+
+        assertCommandFailure(editCommand, model, expectedErrorMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/InspectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/InspectCommandTest.java
@@ -2,11 +2,37 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code InspectCommand}.
+ */
 public class InspectCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_outOfBoundIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        InspectCommand inspectCommand = new InspectCommand(outOfBoundIndex);
+        String expectedErrorMessage = String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                outOfBoundIndex.getOneBased());
+
+        assertCommandFailure(inspectCommand, model, expectedErrorMessage);
+    }
+
     @Test
     public void equals() {
         InspectCommand inspectFirstCommand = new InspectCommand(INDEX_FIRST);

--- a/src/test/java/seedu/address/logic/commands/UnarchiveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnarchiveCommandTest.java
@@ -3,7 +3,11 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_DUPLICATED_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_LIST;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_LIST;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -53,6 +57,31 @@ public class UnarchiveCommandTest {
         AddressBookParser.setInspect(false);
         model.addPerson(archivedPerson);
         assertCommandSuccess(unarchiveCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_outOfBoundIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        List<Index> outOfBoundIndexList = new ArrayList<>();
+        outOfBoundIndexList.add(outOfBoundIndex);
+        UnarchiveCommand unarchiveCommand = new UnarchiveCommand(outOfBoundIndexList);
+        String expectedErrorMessage = String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                outOfBoundIndex.getOneBased());
+
+        assertCommandFailure(unarchiveCommand, model, expectedErrorMessage);
+    }
+
+    @Test
+    public void execute_duplicateIndexUnfilteredList_throwsCommandException() {
+        List<Index> duplicatedList = new ArrayList<>();
+        duplicatedList.add(INDEX_FIRST);
+        duplicatedList.add(INDEX_FIRST);
+        UnarchiveCommand unarchiveCommand = new UnarchiveCommand(duplicatedList);
+
+        String expectedErrorMessage = String.format(MESSAGE_INVALID_DUPLICATED_INDEX,
+                INDEX_FIRST.getOneBased());
+
+        assertCommandFailure(unarchiveCommand, model, expectedErrorMessage);
     }
 
     @Test


### PR DESCRIPTION
# Add index for the invalid indexes or duplicate indexes

Commands with modified changes
- `delete` command for both `person` and `delivery` when there is **duplicate** or **out-of-bound** index
- `archive` & `unarchive` commands for both `person` and `delivery` when there is **duplicate** or **out-of-bound** index
- `edit` command for both `person` and `delivery` when the index is **out-of-bound**
- `inspect` command for `person` when the index is **out-of-bound**

Example of changes made: 

![image](https://github.com/user-attachments/assets/b5de1d46-bb35-4238-a450-bf020aa84bdc)