### PR TITLE
Update UG to include glossary and to fix typos

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -25,6 +25,7 @@ LogiLink allows you to manage your contacts on your desktop with keyboard comman
 * [FAQ](#faq)
 * [Known issues](#known-issues)
 * [Command summary](#command-summary)
+* [Glossary](#glossary)
 
 <page-nav-print />
 
@@ -187,48 +188,54 @@ Find command does not work in the inspect window.
 ### Archiving a contact or delivery : `archive`
 **<ins>When in the main window**
 
-Archives the specified contact from the contacts list.
+Archives the specified contact from the contacts list. Archived items will have its visibility reduced and be moved to the end of the list. 
 
 Format: `archive [INDEXES]...`
 
 * Archive the contact(s) at the specified `INDEXES`.
 * The indexes refer to the indexes shown in the displayed contacts list.
 * The indexes **must be positive integers** 1, 2, 3, …​
+* The indexes **must not have duplicates**. For example, `archive 1 2 2 4` is not allowed. 
 
 Examples:
-* `list` followed by `archive 2 3` reduces the visibility of the 2nd and 3rd contact and moves them to the end of the contacts list.
-* `find Betsy` followed by `archive 1` archives the 1st person in the results of the `find` command.
+* `list` followed by `archive 2 3` archives the 2nd and 3rd contact in the contact list. 
+
+Note: 
+* `inspect INDEX` and `edit INDEX` would not work for archived contact.  
 
 **<ins>When in the inspect window**
 
 Archives the specified delivery from the delivery list of a contact. Everything else is the same as mentioned in the main window section of this command.
 
 Examples:
-* `delete 2` archives the 2nd delivery in the delivery list of the inspected contact.
-* `delete 2 3` archives the 2nd and 3rd deliveries in the delivery list of the inspected contact.
+* `archive 2` archives the 2nd delivery in the delivery list of the inspected contact.
+* `archive 2 3` archives the 2nd and 3rd deliveries in the delivery list of the inspected contact.
 
-### Unarchiving a contact or delivery : `unarchive`
+Note:
+* `edit INDEX` would not work for archived delivery.
+
+### Unarchive a contact or delivery : `unarchive`
 **<ins>When in the main window**
 
-Unarchive the specified contact from the contacts list if they are archived. 
+Unarchive the specified contact from the contacts list if they are archived, the visibility of the contact would be restored.  
 
 Format: `unarchive [INDEXES]...`
 
-* Unarchive the contact(s) at the specified `INDEXES`.
+* Undo the archive command the contact(s) at the specified `INDEXES`.
 * The indexes refer to the indexes shown in the displayed contacts list.
 * The indexes **must be positive integers** 1, 2, 3, …​
+* The indexes **must not have duplicates**. For example, `unarchive 1 2 2 4 ` is not allowed.
 
 Examples:
 * `list` followed by `unarchive 2 3` unarchives the 2nd and 3rd contact in the contacts list.
-* `find Betsy` followed by `unarchive 1` deletes the 1st person in the results of the `find` command.
 
 **<ins>When in the inspect window**
 
 Unarchives the specified delivery from the delivery list of a contact. Everything else is the same as mentioned in the main window section of this command.
 
 Examples:
-* `unarchive 2` deletes the 2nd delivery in the delivery list of the inspected contact.
-* `unarchive 2 3` deletes the 2nd and 3rd deliveries in the delivery list of the inspected contact.
+* `unarchive 2` unarchives the 2nd delivery in the delivery list of the inspected contact.
+* `unarchive 2 3` unarchives the 2nd and 3rd deliveries in the delivery list of the inspected contact.
 
 ### Deleting a contact or delivery : `delete`
 **<ins>When in the main window**
@@ -325,7 +332,7 @@ Furthermore, certain edits can cause the LogiLink to behave in unexpected ways (
 Action     | Format, Examples
 -----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL r/ROLE a/ADDRESS [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com r/Client a/123, Clementi Rd, 1234665 t/friend t/colleague`
-**Archive** | `archive INDEXES`<br> e.g., `archive 3`, `archive 3 4`
+**Archive**| `archive INDEXES`<br> e.g., `archive 3`, `archive 3 4`
 **Clear**  | `clear`
 **Delete** | `delete INDEXES`<br> e.g., `delete 3`, `delete 3 4`
 **Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
@@ -333,5 +340,13 @@ Action     | Format, Examples
 **Inspect**| `inspect INDEX`<br> e.g., `inspect 2`
 **List**   | `list`
 **Help**   | `help`
-**Unarchive** | `unarchive INDEXES`<br> e.g., `unarchive 3`, `unarchive 3 4`
+**Unarchive**| `unarchive INDEXES`<br> e.g., `unarchive 3`, `unarchive 3 4`
 
+--------------------------------------------------------------------------------------------------------------------
+
+## Glossary
+
+Terms            | Meaning
+-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+**Archive**      |The action of moving an item, from an active or accessible state to a preserved state by reducing its immediate availability and visibility.
+**Unarchive**    |The action of restoring a previously archived item, to an active or accessible state.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -188,20 +188,20 @@ Find command does not work in the inspect window.
 ### Archiving a contact or delivery : `archive`
 **<ins>When in the main window**
 
-Archives the specified contact from the contacts list. Archived items will have its visibility reduced and be moved to the end of the list. 
+Archives the specified contact from the contacts list. Archived items will have its visibility reduced and be moved to the end of the list.
 
 Format: `archive [INDEXES]...`
 
 * Archive the contact(s) at the specified `INDEXES`.
 * The indexes refer to the indexes shown in the displayed contacts list.
 * The indexes **must be positive integers** 1, 2, 3, …​
-* The indexes **must not have duplicates**. For example, `archive 1 2 2 4` is not allowed. 
+* The indexes **must not have duplicates**. For example, `archive 1 2 2 4` is not allowed.
 
 Examples:
-* `list` followed by `archive 2 3` archives the 2nd and 3rd contact in the contact list. 
+* `list` followed by `archive 2 3` archives the 2nd and 3rd contact in the contact list.
 
-Note: 
-* `inspect INDEX` and `edit INDEX` would not work for archived contact.  
+Note:
+* `inspect INDEX` and `edit INDEX` would not work for archived contact.
 
 **<ins>When in the inspect window**
 
@@ -217,7 +217,7 @@ Note:
 ### Unarchive a contact or delivery : `unarchive`
 **<ins>When in the main window**
 
-Unarchive the specified contact from the contacts list if they are archived, the visibility of the contact would be restored.  
+Unarchive the specified contact from the contacts list if they are archived, the visibility of the contact would be restored.
 
 Format: `unarchive [INDEXES]...`
 
@@ -242,7 +242,7 @@ Examples:
 
 Deletes the specified contact from the contacts list.
 
-Format: `delete [INDEXES]...` 
+Format: `delete [INDEXES]...`
 
 * Deletes the contact(s) at the specified `INDEXES`.
 * The indexes refer to the indexes shown in the displayed contacts list.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,10 @@
 [![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
 [![codecov](https://codecov.io/gh/se-edu/addressbook-level3/branch/master/graph/badge.svg)](https://codecov.io/gh/se-edu/addressbook-level3)
 
-**Main Window**  
+**Main Window**
 ![Ui](images/Ui.png)
 
-**Inspect Window**  
+**Inspect Window**
 ![Ui2](images/Ui2.png)
 
 **AddressBook is a desktop application for managing your contact details.** While it has a GUI, most of the user interactions happen using a CLI (Command Line Interface).


### PR DESCRIPTION
Edit UserGuide.md to fix typos in the Unarchive command section. 
Added a `Glossary` section to include the definition of archive and unarchive. 