### PR TITLE
Modify result display for invalid inputs

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -94,7 +94,7 @@ public class Messages {
                 builder.append(indexList.get(i).getOneBased());
                 continue;
             }
-            builder.append(",").append(indexList.get(i).getOneBased());
+            builder.append(", ").append(indexList.get(i).getOneBased());
         }
 
         return builder.toString().trim();

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.delivery.Delivery;
 import seedu.address.model.person.Person;
@@ -79,6 +80,18 @@ public class Messages {
             .append("; ")
             .append(delivery.getTime());
         return builder.toString();
+    }
+
+    /**
+     * Formats the list of {@code index} for display to the user.
+     */
+    public static String formatIndexList(List<Index> indexList) {
+        final StringBuilder builder = new StringBuilder();
+        for (Index index : indexList) {
+            builder.append(" ").append(index.getOneBased());
+        }
+
+        return builder.toString().trim();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -86,9 +86,15 @@ public class Messages {
      * Formats the list of {@code index} for display to the user.
      */
     public static String formatIndexList(List<Index> indexList) {
+        //indexList should not be empty
         final StringBuilder builder = new StringBuilder();
-        for (Index index : indexList) {
-            builder.append(" ").append(index.getOneBased());
+
+        for (int i = 0; i < indexList.size(); i++) {
+            if (i == 0) {
+                builder.append(indexList.get(i).getOneBased());
+                continue;
+            }
+            builder.append(",").append(indexList.get(i).getOneBased());
         }
 
         return builder.toString().trim();

--- a/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
@@ -2,7 +2,12 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;

--- a/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
@@ -2,12 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
@@ -130,25 +125,30 @@ public class ArchiveCommand extends Command {
      * @throws CommandException if any index is out of bounds or if duplicates are found.
      */
     private void validateIndexes(int listSize, List<Index> indexList, boolean isDelivery) throws CommandException {
-        boolean hasDuplicate = hasDuplicates(indexList);
-        for (Index targetIndex : indexList) {
-            if (targetIndex.getZeroBased() >= listSize) {
-                if (isDelivery) {
-                    throw new CommandException(
-                            String.format(Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX,
-                                    targetIndex.getOneBased()));
-                } else {
-                    throw new CommandException(
-                            String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
-                                    targetIndex.getOneBased()));
-                }
-            }
+        List<Index> outOfBoundList = getOutOfBoundList(indexList, listSize);
+        List<Index> duplicateList = getDuplicateList(indexList);
+        String exceptionMessage = "";
 
-            if (hasDuplicate) {
-                throw new CommandException(
-                        String.format(Messages.MESSAGE_INVALID_DUPLICATED_INDEX,
-                                targetIndex.getOneBased()));
+        if (!outOfBoundList.isEmpty()) {
+            if (isDelivery) {
+                exceptionMessage = String.format(Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX,
+                        Messages.formatIndexList(outOfBoundList));
+            } else {
+                exceptionMessage = String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                        Messages.formatIndexList(outOfBoundList));
             }
+        }
+
+        if (!duplicateList.isEmpty()) {
+            if (!exceptionMessage.isEmpty()) {
+                exceptionMessage = exceptionMessage + "\n";
+            }
+            exceptionMessage = exceptionMessage + String.format(Messages.MESSAGE_INVALID_DUPLICATED_INDEX,
+                    Messages.formatIndexList(duplicateList));
+        }
+
+        if (!outOfBoundList.isEmpty() || !duplicateList.isEmpty()) {
+            throw new CommandException(exceptionMessage);
         }
     }
 
@@ -258,19 +258,42 @@ public class ArchiveCommand extends Command {
     }
 
     /**
-     * Checks if a list of indexes has any duplicates.
+     * Returns a list of indexes containing duplicates.
      *
      * @param indexList the list of indexes to check
-     * @return true if the list has duplicates, false otherwise
+     * @return a list containing duplicates, an empty list otherwise
      */
-    private boolean hasDuplicates(List<Index> indexList) {
+    private List<Index> getDuplicateList(List<Index> indexList) {
+        List<Index> duplicateList = new ArrayList<>();
         Set<Integer> uniqueIndices = new HashSet<>();
         for (Index index : indexList) {
-            if (!uniqueIndices.add(index.getZeroBased())) {
-                return true; // duplicate found
+            if (!uniqueIndices.add(index.getZeroBased()) && !duplicateList.contains(index)) {
+                duplicateList.add(index);
             }
         }
-        return false; // no duplicates found
+        duplicateList.sort(Comparator.comparingInt(Index::getOneBased));
+        return duplicateList;
+    }
+
+    /**
+     * Returns a list of out-of-bound indexes.
+     *
+     * @param indexList the list of indexes to check
+     * @return list of index containing out-of-bound indexes
+     */
+    private List<Index> getOutOfBoundList(List<Index> indexList, int listSize) {
+        List<Index> invalidIndexList = new ArrayList<>();
+        for (Index index : indexList) {
+            if (invalidIndexList.contains(index)) {
+                continue;
+            }
+
+            if (index.getZeroBased() >= listSize || index.getZeroBased() < 0) {
+                invalidIndexList.add(index);
+            }
+        }
+        invalidIndexList.sort(Comparator.comparingInt(Index::getOneBased));
+        return invalidIndexList;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -105,26 +105,31 @@ public class DeleteCommand extends Command {
      * @param indexList The list of indexes to be validated.
      * @throws CommandException if any index is out of bounds or if duplicates are found.
      */
-    private void validateIndexes(int listSize, List<Index> indexList, boolean isPersonIndex) throws CommandException {
-        boolean duplicate = hasDuplicates(indexList);
-        for (Index targetIndex : indexList) {
-            if (targetIndex.getZeroBased() >= listSize) {
-                if (isPersonIndex) {
-                    throw new CommandException(
-                            String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
-                                    targetIndex.getOneBased()));
-                } else {
-                    throw new CommandException(
-                            String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
-                                    targetIndex.getOneBased()));
-                }
-            }
+    private void validateIndexes(int listSize, List<Index> indexList, boolean isDelivery) throws CommandException {
+        List<Index> outOfBoundList = getOutOfBoundList(indexList, listSize);
+        List<Index> duplicateList = getDuplicateList(indexList);
+        String exceptionMessage = "";
 
-            if (duplicate) {
-                throw new CommandException(
-                        String.format(Messages.MESSAGE_INVALID_DUPLICATED_INDEX,
-                                targetIndex.getOneBased()));
+        if (!outOfBoundList.isEmpty()) {
+            if (isDelivery) {
+                exceptionMessage = String.format(Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX,
+                        Messages.formatIndexList(outOfBoundList));
+            } else {
+                exceptionMessage = String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                        Messages.formatIndexList(outOfBoundList));
             }
+        }
+
+        if (!duplicateList.isEmpty()) {
+            if (!exceptionMessage.isEmpty()) {
+                exceptionMessage = exceptionMessage + "\n";
+            }
+            exceptionMessage = exceptionMessage + String.format(Messages.MESSAGE_INVALID_DUPLICATED_INDEX,
+                    Messages.formatIndexList(duplicateList));
+        }
+
+        if (!outOfBoundList.isEmpty() || !duplicateList.isEmpty()) {
+            throw new CommandException(exceptionMessage);
         }
     }
 
@@ -176,19 +181,42 @@ public class DeleteCommand extends Command {
     }
 
     /**
-     * Checks if a list of indexes has any duplicates.
+     * Returns a list of indexes containing duplicates.
      *
      * @param indexList the list of indexes to check
-     * @return true if the list has duplicates, false otherwise
+     * @return a list containing duplicates, an empty list otherwise
      */
-    private boolean hasDuplicates(List<Index> indexList) {
+    private List<Index> getDuplicateList(List<Index> indexList) {
+        List<Index> duplicateList = new ArrayList<>();
         Set<Integer> uniqueIndices = new HashSet<>();
         for (Index index : indexList) {
-            if (!uniqueIndices.add(index.getZeroBased())) {
-                return true; // duplicate found
+            if (!uniqueIndices.add(index.getZeroBased()) && !duplicateList.contains(index)) {
+                duplicateList.add(index);
             }
         }
-        return false; // no duplicates found
+        duplicateList.sort(Comparator.comparingInt(Index::getOneBased));
+        return duplicateList;
+    }
+
+    /**
+     * Returns a list of out-of-bound indexes.
+     *
+     * @param indexList the list of indexes to check
+     * @return list of index containing out-of-bound indexes
+     */
+    private List<Index> getOutOfBoundList(List<Index> indexList, int listSize) {
+        List<Index> invalidIndexList = new ArrayList<>();
+        for (Index index : indexList) {
+            if (invalidIndexList.contains(index)) {
+                continue;
+            }
+
+            if (index.getZeroBased() >= listSize || index.getZeroBased() < 0) {
+                invalidIndexList.add(index);
+            }
+        }
+        invalidIndexList.sort(Comparator.comparingInt(Index::getOneBased));
+        return invalidIndexList;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -68,7 +68,7 @@ public class DeleteCommand extends Command {
     private CommandResult handlePersonDeletion(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
-        validateIndexes(lastShownList.size(), indexList, true);
+        validateIndexes(lastShownList.size(), indexList, false);
 
         List<Person> personToDeleteList = deletePersons(model, lastShownList);
 
@@ -87,7 +87,7 @@ public class DeleteCommand extends Command {
         requireNonNull(model);
         Person inspectedPerson = InspectWindow.getInspectedPerson();
         List<Delivery> deliveryList = inspectedPerson.getUnmodifiableDeliveryList();
-        validateIndexes(deliveryList.size(), indexList, false);
+        validateIndexes(deliveryList.size(), indexList, true);
 
         List<Delivery> deliveryToDeleteList = deleteDeliveries(inspectedPerson, deliveryList);
 

--- a/src/main/java/seedu/address/logic/commands/InspectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/InspectCommand.java
@@ -24,7 +24,6 @@ public class InspectCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_INSPECT_SUCCESS = "Inspected person: %1$s";
-    public static final String MESSAGE_INSPECT_INVALID = "Inspected person: %1$s";
     private final Index index;
 
     /**

--- a/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
@@ -197,22 +197,6 @@ public class UnarchiveCommand extends Command {
     }
 
     /**
-     * Checks if a list of indexes has any duplicates.
-     *
-     * @param indexList the list of indexes to check
-     * @return true if the list has duplicates, false otherwise
-     */
-    private boolean hasDuplicates(List<Index> indexList) {
-        Set<Integer> uniqueIndices = new HashSet<>();
-        for (Index index : indexList) {
-            if (!uniqueIndices.add(index.getZeroBased())) {
-                return true; // duplicate found
-            }
-        }
-        return false; // no duplicates found
-    }
-
-    /**
      * Validates the indexes in the indexList to ensure none are out of bounds or duplicates.
      *
      * @param listSize The size of the list from which items are to be deleted.
@@ -220,26 +204,70 @@ public class UnarchiveCommand extends Command {
      * @throws CommandException if any index is out of bounds or if duplicates are found.
      */
     private void validateIndexes(int listSize, List<Index> indexList, boolean isDelivery) throws CommandException {
-        boolean hasDuplicate = hasDuplicates(indexList);
-        for (Index targetIndex : indexList) {
-            if (targetIndex.getZeroBased() >= listSize) {
-                if (isDelivery) {
-                    throw new CommandException(
-                            String.format(Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX,
-                                    targetIndex.getOneBased()));
-                } else {
-                    throw new CommandException(
-                            String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
-                                    targetIndex.getOneBased()));
-                }
-            }
+        List<Index> outOfBoundList = getOutOfBoundList(indexList, listSize);
+        List<Index> duplicateList = getDuplicateList(indexList);
+        String exceptionMessage = "";
 
-            if (hasDuplicate) {
-                throw new CommandException(
-                        String.format(Messages.MESSAGE_INVALID_DUPLICATED_INDEX,
-                                targetIndex.getOneBased()));
+        if (!outOfBoundList.isEmpty()) {
+            if (isDelivery) {
+                exceptionMessage = String.format(Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX,
+                        Messages.formatIndexList(outOfBoundList));
+            } else {
+                exceptionMessage = String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                        Messages.formatIndexList(outOfBoundList));
             }
         }
+
+        if (!duplicateList.isEmpty()) {
+            if (!exceptionMessage.isEmpty()) {
+                exceptionMessage = exceptionMessage + "\n";
+            }
+            exceptionMessage = exceptionMessage + String.format(Messages.MESSAGE_INVALID_DUPLICATED_INDEX,
+                    Messages.formatIndexList(duplicateList));
+        }
+
+        if (!outOfBoundList.isEmpty() || !duplicateList.isEmpty()) {
+            throw new CommandException(exceptionMessage);
+        }
+    }
+
+    /**
+     * Returns a list of indexes containing duplicates.
+     *
+     * @param indexList the list of indexes to check
+     * @return a list containing duplicates, an empty list otherwise
+     */
+    private List<Index> getDuplicateList(List<Index> indexList) {
+        List<Index> duplicateList = new ArrayList<>();
+        Set<Integer> uniqueIndices = new HashSet<>();
+        for (Index index : indexList) {
+            if (!uniqueIndices.add(index.getZeroBased()) && !duplicateList.contains(index)) {
+                duplicateList.add(index);
+            }
+        }
+        duplicateList.sort(Comparator.comparingInt(Index::getOneBased));
+        return duplicateList;
+    }
+
+    /**
+     * Returns a list of out-of-bound indexes.
+     *
+     * @param indexList the list of indexes to check
+     * @return list of index containing out-of-bound indexes
+     */
+    private List<Index> getOutOfBoundList(List<Index> indexList, int listSize) {
+        List<Index> invalidIndexList = new ArrayList<>();
+        for (Index index : indexList) {
+            if (invalidIndexList.contains(index)) {
+                continue;
+            }
+
+            if (index.getZeroBased() >= listSize || index.getZeroBased() < 0) {
+                invalidIndexList.add(index);
+            }
+        }
+        invalidIndexList.sort(Comparator.comparingInt(Index::getOneBased));
+        return invalidIndexList;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -125,7 +125,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         Index index;
         try {
             List<Index> indexList = ParserUtil.parseIndex(argMultimap.getPreamble());
-            if (indexList.isEmpty()) {
+            if (indexList.isEmpty() || indexList.size() > 1) {
                 throw new ParseException(MESSAGE_INVALID_INDEX);
             }
             index = indexList.get(0);

--- a/src/main/java/seedu/address/logic/parser/InspectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/InspectCommandParser.java
@@ -26,7 +26,7 @@ public class InspectCommandParser implements Parser<InspectCommand> {
         Index index;
         try {
             List<Index> indexList = ParserUtil.parseIndex(args);
-            if (indexList.isEmpty()) {
+            if (indexList.isEmpty() || indexList.size() > 1) {
                 throw new ParseException(MESSAGE_INVALID_INDEX);
             }
             index = indexList.get(0);


### PR DESCRIPTION
Modify the help message when invalid inputs, such as out-of-bound inputs or duplicate inputs are inserted. 
Refer to #129 for more information. 

![image](https://github.com/user-attachments/assets/6a0eca17-150a-4af2-b2db-19329f9c6e86)