### PR TITLE
Add list commands to filter clients and employees

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -76,6 +76,10 @@ public class LogicManager implements Logic {
         return model.getOnlyClientList();
     }
 
+    public ObservableList<Person> getOnlyEmployeeList() {
+        return model.getOnlyEmployeeList();
+    }
+
     @Override
     public Path getAddressBookFilePath() {
         return model.getAddressBookFilePath();

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,9 +1,13 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_DELIVERIES;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ONLY_CLIENTS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ONLY_EMPLOYEES;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
@@ -20,21 +24,46 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS_DELIVERY = "Listed all deliveries";
 
+    public static final String MESSAGE_SUCCESS_SHOW_CLIENTS = "Listed all clients";
+
+    public static final String MESSAGE_SUCCESS_SHOW_EMPLOYEES = "Listed all employees";
+
+    private String target;
+
+    public ListCommand(String target) {
+        this.target = target;
+    }
+
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        model.updateFilteredDeliveryList(PREDICATE_SHOW_ALL_DELIVERIES);
-        boolean isInspect = AddressBookParser.getInspect();
-        Person inspectedPerson;
-        String message;
-        if (isInspect) {
-            inspectedPerson = InspectWindow.getInspectedPerson();
-            message = MESSAGE_SUCCESS_DELIVERY;
-        } else {
-            inspectedPerson = null;
-            message = MESSAGE_SUCCESS_PERSON;
+        if (target.equalsIgnoreCase("all")) {
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            model.updateFilteredDeliveryList(PREDICATE_SHOW_ALL_DELIVERIES);
+            boolean isInspect = AddressBookParser.getInspect();
+            Person inspectedPerson;
+            String message;
+            if (isInspect) {
+                inspectedPerson = InspectWindow.getInspectedPerson();
+                message = MESSAGE_SUCCESS_DELIVERY;
+            } else {
+                inspectedPerson = null;
+                message = MESSAGE_SUCCESS_PERSON;
+            }
+            return new CommandResult(message, inspectedPerson, false, false, isInspect, !isInspect);
         }
-        return new CommandResult(message, inspectedPerson, false, false, isInspect, !isInspect);
+
+        if (target.equals("employees")) {
+            model.updateFilteredPersonList(PREDICATE_SHOW_ONLY_EMPLOYEES);
+            return new CommandResult(
+                    MESSAGE_SUCCESS_SHOW_EMPLOYEES, null, false, false, false, true);
+        }
+
+        if (target.equals("clients")) {
+            model.updateFilteredPersonList(PREDICATE_SHOW_ONLY_CLIENTS);
+            return new CommandResult(
+                    MESSAGE_SUCCESS_SHOW_CLIENTS, null, false, false, false, true);
+        }
+        throw new CommandException(MESSAGE_UNKNOWN_COMMAND);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,21 +8,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ArchiveCommand;
-import seedu.address.logic.commands.BackCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.FinddelCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.InspectCommand;
-import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.SortCommand;
-import seedu.address.logic.commands.UnarchiveCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,7 +62,7 @@ public class AddressBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case InspectCommand.COMMAND_WORD:
             return new InspectCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,7 +8,21 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ArchiveCommand;
+import seedu.address.logic.commands.BackCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FinddelCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.InspectCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.commands.UnarchiveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ListCommand object
+ */
+
+public class ListCommandParser implements Parser<ListCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListCommand parse(String args) throws ParseException {
+
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            return new ListCommand("all");
+        }
+
+        if (trimmedArgs.equalsIgnoreCase("employees")) {
+            return new ListCommand("employees");
+        }
+
+        if (trimmedArgs.equalsIgnoreCase("clients")) {
+            return new ListCommand("clients");
+        }
+
+        throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+    }
+
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -19,6 +19,7 @@ public interface Model {
     /** {@code Predicate} that always evaluates to true */
     Predicate<Delivery> PREDICATE_SHOW_ALL_DELIVERIES = unused -> true;
     Predicate<Person> PREDICATE_SHOW_ONLY_CLIENTS = person -> person.getRole().getValue().equals("client");
+    Predicate<Person> PREDICATE_SHOW_ONLY_EMPLOYEES = person -> person.getRole().getValue().equals("employee");
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -129,6 +130,8 @@ public interface Model {
     ObservableList<Person> getFilteredPersonList();
 
     ObservableList<Person> getOnlyClientList();
+
+    ObservableList<Person> getOnlyEmployeeList();
 
     /** Returns the {@code Index} of the first archived person in the list. */
     Index getFirstArchivedIndex();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -174,6 +174,11 @@ public class ModelManager implements Model {
         return filteredPersons;
     }
 
+    public ObservableList<Person> getOnlyEmployeeList() {
+        filteredPersons.setPredicate(PREDICATE_SHOW_ONLY_EMPLOYEES);
+        return filteredPersons;
+    }
+
     @Override
     public Index getFirstArchivedIndex() {
         return this.addressBook.getFirstArchivedIndex();

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -219,6 +219,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public ObservableList<Person> getOnlyEmployeeList() {
+            return null;
+        }
+
+        @Override
         public Index getFirstArchivedIndex() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -30,12 +30,12 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS_PERSON, expectedModel);
+        assertCommandSuccess(new ListCommand("all"), model, ListCommand.MESSAGE_SUCCESS_PERSON, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS_PERSON, expectedModel);
+        assertCommandSuccess(new ListCommand("all"), model, ListCommand.MESSAGE_SUCCESS_PERSON, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -107,7 +107,6 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
     }
 
     @Test


### PR DESCRIPTION
Added `list clients` and `list employees` command. 
Throw error when there are other parsers placed after `list`. 