### PR TITLE
Add error message when using back command in Main Window

### DIFF
--- a/src/main/java/seedu/address/logic/commands/BackCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BackCommand.java
@@ -16,10 +16,19 @@ public class BackCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Returned to main window";
 
+    public static final String MESSAGE_INVALID_COMMAND = "This command cannot be ran in the main window!";
+
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+
+        String message = MESSAGE_SUCCESS;
+
+        if (!AddressBookParser.getInspect()) {
+            message = MESSAGE_INVALID_COMMAND;
+        }
+
         AddressBookParser.setInspect(false);
-        return new CommandResult(MESSAGE_SUCCESS, null, false, false, false, true);
+        return new CommandResult(message, null, false, false, false, true);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/BackCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/BackCommandTest.java
@@ -21,6 +21,6 @@ public class BackCommandTest {
     @Test
     public void execute_inMainWindow_staysMainWindow() {
         AddressBookParser.setInspect(false);
-        assertCommandSuccess(new BackCommand(), model, BackCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new BackCommand(), model, BackCommand.MESSAGE_INVALID_COMMAND, expectedModel);
     }
 }


### PR DESCRIPTION
Instead of allowing the `back` command to run in the main window, an error message would be thrown instead. 
![image](https://github.com/user-attachments/assets/74bba89a-a5c6-449c-aafe-3ea38d818325)
