### PR TITLE
Document issues with back command in main window

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -457,6 +457,9 @@ Certain changes you make to the file could cause LogiLink to behave unexpectedly
  - If you are using multiple screens and move the app to a secondary screen, then later switch to using only the primary screen, the app might open off-screen. 
  - To fix this, simply delete the `preferences.json` file created by the app, then restart the app.
 
+2. **When using `back` command in Main Window**
+ - If you are using `back` command in the Main Window, instead of throwing out a message `This command cannot be ran in the main window!`, a `Returned to Main Window` would be displayed instead, along with a successful command call. 
+
 --------------------------------------------------------------------------------------------------------------------
 
 ## Command summary


### PR DESCRIPTION
Follow up from #263 

> Can either put it under 'known limitations' or 'planned enhancements': ![image](https://private-user-images.githubusercontent.com/122229748/384692811-fc6741a0-0634-4dd5-8014-0674cf2e872d.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzEzNDIyNjcsIm5iZiI6MTczMTM0MTk2NywicGF0aCI6Ii8xMjIyMjk3NDgvMzg0NjkyODExLWZjNjc0MWEwLTA2MzQtNGRkNS04MDE0LTA2NzRjZjJlODcyZC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQxMTExJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MTExMVQxNjE5MjdaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT05OTQ3OTIzZjEzYjhmZGEwN2NhNGM1ZThhZTFkMDM1YjhhNDU0MzRlZDQ3MjVlMjkxZDY3YTNjNzQ1MDBiYWJiJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.FDxwnohUA75ITKkOVpkh-sFjiaBEL_gLcuacMxhfcu4)
> 
> Or can document it under the "back" command section of UG as something to note.

### Changes Made
 - Documented the issues of `back` command in Main Window to `known limitations` of the UG. 