### PR TITLE
Resolve bug with archive, find and inspect

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -186,7 +186,7 @@ public class ModelManager implements Model {
 
     @Override
     public Index getFirstArchivedIndex() {
-        int count = (int) filteredPersons.stream().filter(person -> person.isArchived()).count();
+        int count = (int) filteredPersons.stream().filter(person -> !person.isArchived()).count();
         Index index = Index.fromZeroBased(count);
         return index;
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -186,7 +186,9 @@ public class ModelManager implements Model {
 
     @Override
     public Index getFirstArchivedIndex() {
-        return this.addressBook.getFirstArchivedIndex();
+        int count = (int) filteredPersons.stream().filter(person -> person.isArchived()).count();
+        Index index = Index.fromZeroBased(count);
+        return index;
     }
 
     @Override


### PR DESCRIPTION
Refer to #235. 

After changes made, throws error message when completing the steps below, 

Pre-requisite: assuming there is only one contact named `John`

1. `archive 1`, where 1 is the person John
2. `find John`, which shows you a filtered list containing John, which is an archived contact
3. `inspect 1`, and error message would be throw to indicate that user cannot inspect archived contact