### PR TITLE
Fix finddel causing other commands to fail

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
@@ -74,11 +74,11 @@ public class ArchiveCommand extends Command {
         indexList.sort(Comparator.comparing(Index::getZeroBased).reversed());
 
         if (AddressBookParser.getInspect()) {
-            return handleDeliveryArchive(model);
-        } else {
             if (InspectWindow.getInspectedPerson().getRole().getValue().equals("employee")) {
                 throw new CommandException(MESSAGE_CANNOT_ARCHIVE_FOR_EMPLOYEE);
             }
+            return handleDeliveryArchive(model);
+        } else {
             return handlePersonArchive(model);
         }
     }

--- a/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
@@ -93,7 +93,7 @@ public class ArchiveCommand extends Command {
     private CommandResult handleDeliveryArchive(Model model) throws CommandException {
         requireNonNull(model);
         Person inspectedPerson = InspectWindow.getInspectedPerson();
-        List<Delivery> deliveryList= model.getFilteredDeliveryList();
+        List<Delivery> deliveryList = model.getFilteredDeliveryList();
         validateIndexes(deliveryList.size(), indexList, true);
 
         List<Delivery> deliveryToArchiveList = archiveDeliveries(inspectedPerson, deliveryList);

--- a/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
@@ -19,7 +19,6 @@ import seedu.address.model.delivery.Cost;
 import seedu.address.model.delivery.Date;
 import seedu.address.model.delivery.Delivery;
 import seedu.address.model.delivery.DeliveryId;
-import seedu.address.model.delivery.DeliveryList;
 import seedu.address.model.delivery.Eta;
 import seedu.address.model.delivery.ItemName;
 import seedu.address.model.delivery.Status;
@@ -55,11 +54,13 @@ public class ArchiveCommand extends Command {
 
     public static final String MESSAGE_ARCHIVED_DELIVERY_SUCCESS = "Archived Delivery for %1$s: %2$s";
 
-
     public static final String MESSAGE_ARCHIVED_PERSON_SUCCESS = "Archived Person: %1$s";
 
     public static final String MESSAGE_INVALID_WINDOW = "Cannot archive contact. "
             + "Navigate to inspection window to archive deliveries";
+
+    public static final String MESSAGE_CANNOT_ARCHIVE_FOR_EMPLOYEE = "Cannot archive for employee. This currently only"
+            + " works for clients";
 
     private final List<Index> indexList;
 
@@ -75,6 +76,9 @@ public class ArchiveCommand extends Command {
         if (AddressBookParser.getInspect()) {
             return handleDeliveryArchive(model);
         } else {
+            if (InspectWindow.getInspectedPerson().getRole().getValue().equals("employee")) {
+                throw new CommandException(MESSAGE_CANNOT_ARCHIVE_FOR_EMPLOYEE);
+            }
             return handlePersonArchive(model);
         }
     }
@@ -89,8 +93,8 @@ public class ArchiveCommand extends Command {
     private CommandResult handleDeliveryArchive(Model model) throws CommandException {
         requireNonNull(model);
         Person inspectedPerson = InspectWindow.getInspectedPerson();
-        DeliveryList deliveryList = inspectedPerson.getDeliveryList();
-        validateIndexes(inspectedPerson.getDeliveryListSize(), indexList, true);
+        List<Delivery> deliveryList= model.getFilteredDeliveryList();
+        validateIndexes(deliveryList.size(), indexList, true);
 
         List<Delivery> deliveryToArchiveList = archiveDeliveries(inspectedPerson, deliveryList);
 
@@ -164,16 +168,16 @@ public class ArchiveCommand extends Command {
      * @param deliveryList The list of deliveries to archive from.
      * @return A list of deliveries that were archived.
      */
-    private List<Delivery> archiveDeliveries(Person inspectedPerson, DeliveryList deliveryList) {
+    private List<Delivery> archiveDeliveries(Person inspectedPerson, List<Delivery> deliveryList) {
         List<Delivery> deliveryToArchiveList = new ArrayList<>();
         List<Delivery> deliveryToAddList = new ArrayList<>();
 
         for (Index targetIndex : indexList) {
-            Delivery deliveryToArchive = deliveryList.asUnmodifiableObservableList().get(targetIndex.getZeroBased());
+            Delivery deliveryToArchive = deliveryList.get(targetIndex.getZeroBased());
             Delivery archivedDelivery = createArchivedDelivery(deliveryToArchive);
 
             if (!deliveryToArchive.isArchived()) {
-                inspectedPerson.deleteDelivery(targetIndex);
+                inspectedPerson.deleteDelivery(deliveryToArchive);
                 deliveryToAddList.add(archivedDelivery);
             }
             deliveryToArchiveList.add(archivedDelivery);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -65,7 +65,7 @@ public class DeleteCommand extends Command {
      * @return A CommandResult containing a success message with details of the deleted persons.
      * @throws CommandException if any index in the indexList is out of bounds or if duplicates are found.
      */
-    public CommandResult handlePersonDeletion(Model model) throws CommandException {
+    private CommandResult handlePersonDeletion(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
         validateIndexes(lastShownList.size(), indexList, false);
@@ -83,7 +83,7 @@ public class DeleteCommand extends Command {
      * @return A CommandResult containing a success message with details of the deleted deliveries.
      * @throws CommandException if any index in the indexList is out of bounds or if duplicates are found.
      */
-    public CommandResult handleDeliveryDeletion(Model model) throws CommandException {
+    private CommandResult handleDeliveryDeletion(Model model) throws CommandException {
         requireNonNull(model);
         Person inspectedPerson = InspectWindow.getInspectedPerson();
         List<Delivery> deliveryList = model.getFilteredDeliveryList();
@@ -105,7 +105,7 @@ public class DeleteCommand extends Command {
      * @param lastShownList The list of persons to delete from.
      * @return A list of persons that were deleted.
      */
-    public List<Person> deletePersons(Model model, List<Person> lastShownList) {
+    private List<Person> deletePersons(Model model, List<Person> lastShownList) {
         List<Person> personToDeleteList = new ArrayList<>();
         for (Index targetIndex : indexList) {
             Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
@@ -122,7 +122,7 @@ public class DeleteCommand extends Command {
      * @param deliveryList The list of deliveries to delete from.
      * @return A list of deliveries that were deleted.
      */
-    public List<Delivery> deleteDeliveries(Person inspectedPerson, List<Delivery> deliveryList) {
+    private List<Delivery> deleteDeliveries(Person inspectedPerson, List<Delivery> deliveryList) {
         List<Delivery> deliveryToDeleteList = new ArrayList<>();
         for (Index targetIndex : indexList) {
             Delivery deliveryToDelete = deliveryList.get(targetIndex.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -65,7 +65,7 @@ public class DeleteCommand extends Command {
      * @return A CommandResult containing a success message with details of the deleted persons.
      * @throws CommandException if any index in the indexList is out of bounds or if duplicates are found.
      */
-    private CommandResult handlePersonDeletion(Model model) throws CommandException {
+    public CommandResult handlePersonDeletion(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
         validateIndexes(lastShownList.size(), indexList, false);
@@ -83,19 +83,53 @@ public class DeleteCommand extends Command {
      * @return A CommandResult containing a success message with details of the deleted deliveries.
      * @throws CommandException if any index in the indexList is out of bounds or if duplicates are found.
      */
-    private CommandResult handleDeliveryDeletion(Model model) throws CommandException {
+    public CommandResult handleDeliveryDeletion(Model model) throws CommandException {
         requireNonNull(model);
         Person inspectedPerson = InspectWindow.getInspectedPerson();
-        List<Delivery> deliveryList = inspectedPerson.getUnmodifiableDeliveryList();
+        List<Delivery> deliveryList = model.getFilteredDeliveryList();
         validateIndexes(deliveryList.size(), indexList, true);
 
-        List<Delivery> deliveryToDeleteList = deleteDeliveries(inspectedPerson, deliveryList, model);
+        List<Delivery> deliveryToDeleteList = deleteDeliveries(inspectedPerson, deliveryList);
 
         return new CommandResult(String.format(
                 MESSAGE_DELETE_DELIVERY_SUCCESS,
                 inspectedPerson.getName(),
                 Messages.formatDeliveryList(reverseList(deliveryToDeleteList))),
                 DeliveryAction.DELETE);
+    }
+
+    /**
+     * Deletes persons from the model based on the provided indexList.
+     *
+     * @param model The model containing the filtered person list.
+     * @param lastShownList The list of persons to delete from.
+     * @return A list of persons that were deleted.
+     */
+    public List<Person> deletePersons(Model model, List<Person> lastShownList) {
+        List<Person> personToDeleteList = new ArrayList<>();
+        for (Index targetIndex : indexList) {
+            Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+            personToDeleteList.add(personToDelete);
+            model.deletePerson(personToDelete);
+        }
+        return personToDeleteList;
+    }
+
+    /**
+     * Deletes deliveries from the inspected person's delivery list based on the provided indexList.
+     *
+     * @param inspectedPerson The person whose deliveries are to be deleted.
+     * @param deliveryList The list of deliveries to delete from.
+     * @return A list of deliveries that were deleted.
+     */
+    public List<Delivery> deleteDeliveries(Person inspectedPerson, List<Delivery> deliveryList) {
+        List<Delivery> deliveryToDeleteList = new ArrayList<>();
+        for (Index targetIndex : indexList) {
+            Delivery deliveryToDelete = deliveryList.get(targetIndex.getZeroBased());
+            deliveryToDeleteList.add(deliveryToDelete);
+            inspectedPerson.deleteDelivery(deliveryToDelete);
+        }
+        return deliveryToDeleteList;
     }
 
     /**
@@ -131,40 +165,6 @@ public class DeleteCommand extends Command {
         if (!outOfBoundList.isEmpty() || !duplicateList.isEmpty()) {
             throw new CommandException(exceptionMessage);
         }
-    }
-
-    /**
-     * Deletes persons from the model based on the provided indexList.
-     *
-     * @param model The model containing the filtered person list.
-     * @param lastShownList The list of persons to delete from.
-     * @return A list of persons that were deleted.
-     */
-    private List<Person> deletePersons(Model model, List<Person> lastShownList) {
-        List<Person> personToDeleteList = new ArrayList<>();
-        for (Index targetIndex : indexList) {
-            Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
-            personToDeleteList.add(personToDelete);
-            model.deletePerson(personToDelete);
-        }
-        return personToDeleteList;
-    }
-
-    /**
-     * Deletes deliveries from the inspected person's delivery list based on the provided indexList.
-     *
-     * @param inspectedPerson The person whose deliveries are to be deleted.
-     * @param deliveryList The list of deliveries to delete from.
-     * @return A list of deliveries that were deleted.
-     */
-    private List<Delivery> deleteDeliveries(Person inspectedPerson, List<Delivery> deliveryList, Model model) {
-        List<Delivery> deliveryToDeleteList = new ArrayList<>();
-        for (Index targetIndex : indexList) {
-            Delivery deliveryToDelete = deliveryList.get(targetIndex.getZeroBased());
-            deliveryToDeleteList.add(deliveryToDelete);
-            inspectedPerson.deleteDelivery(targetIndex);
-        }
-        return deliveryToDeleteList;
     }
 
     /**
@@ -221,9 +221,6 @@ public class DeleteCommand extends Command {
 
     /**
      * Check if the list to be deleted are exactly equal
-     *
-     * @param other
-     * @return
      */
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -99,7 +99,8 @@ public class EditCommand extends Command {
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
     public static final String MESSAGE_EDIT_DELIVERY_SUCCESS = "Edited Delivery %d: %2$s";
     public static final String MESSAGE_EMPTY_ITEMS = "At least one item has to be entered";
-
+    public static final String MESSAGE_CANNOT_EDIT_FOR_EMPLOYEE = "Cannot edit delvieries for employee."
+            + " You can only do this in the clients window";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -140,8 +141,11 @@ public class EditCommand extends Command {
             requireNonNull(editPersonDescriptor);
             return editPerson(model);
         } else {
+            if (InspectWindow.getInspectedPerson().getRole().getValue().equals("employee")) {
+                throw new CommandException(MESSAGE_CANNOT_EDIT_FOR_EMPLOYEE);
+            }
             requireNonNull(editDeliveryDescriptor);
-            return editDelivery();
+            return editDelivery(model);
         }
     }
 
@@ -178,12 +182,10 @@ public class EditCommand extends Command {
     /**
      * Edits delivery according to descriptor and returns CommandResult
      */
-    private CommandResult editDelivery() throws CommandException {
+    private CommandResult editDelivery(Model model) throws CommandException {
         Person inspectedPerson = InspectWindow.getInspectedPerson();
 
-        //Currently no filtered list for delivery
-
-        List<Delivery> deliveryList = inspectedPerson.getUnmodifiableDeliveryList();
+        List<Delivery> deliveryList = model.getFilteredDeliveryList();
         if (index.getZeroBased() >= deliveryList.size()) {
             throw new CommandException(
                 String.format(Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX, index.getOneBased())

--- a/src/main/java/seedu/address/logic/commands/RemoveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveCommand.java
@@ -55,7 +55,7 @@ public class RemoveCommand extends Command {
     /**
      * Handles the removal of deliveries from the employee
      */
-    public CommandResult handleDeliveryRemoval(Model model) throws CommandException {
+    private CommandResult handleDeliveryRemoval(Model model) throws CommandException {
         requireNonNull(model);
         Person inspectedPerson = InspectWindow.getInspectedPerson();
         Worker inspectedWorker = inspectedPerson.getWorker();

--- a/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
@@ -63,11 +63,11 @@ public class UnarchiveCommand extends Command {
         indexList.sort(Comparator.comparing(Index::getZeroBased));
 
         if (AddressBookParser.getInspect()) {
-            return handleDeliveryUnarchive(model);
-        } else {
             if (InspectWindow.getInspectedPerson().getRole().getValue().equals("employee")) {
                 throw new CommandException(MESSAGE_CANNOT_UNARCHIVE_FOR_EMPLOYEE);
             }
+            return handleDeliveryUnarchive(model);
+        } else {
             return handlePersonUnarchive(model);
         }
     }

--- a/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
@@ -19,7 +19,6 @@ import seedu.address.model.delivery.Cost;
 import seedu.address.model.delivery.Date;
 import seedu.address.model.delivery.Delivery;
 import seedu.address.model.delivery.DeliveryId;
-import seedu.address.model.delivery.DeliveryList;
 import seedu.address.model.delivery.Eta;
 import seedu.address.model.delivery.ItemName;
 import seedu.address.model.delivery.Status;
@@ -50,6 +49,8 @@ public class UnarchiveCommand extends Command {
 
     public static final String MESSAGE_UNARCHIVED_DELIVERY_SUCCESS = "Unarchived Delivery for %1$s: %2$s";
     public static final String MESSAGE_UNARCHIVED_PERSON_SUCCESS = "Unarchived Person: %1$s";
+    public static final String MESSAGE_CANNOT_UNARCHIVE_FOR_EMPLOYEE = "Cannot unarchive for employee. This currently "
+            + "only works for clients";
     private final List<Index> indexList;
 
     public UnarchiveCommand(List<Index> indexList) {
@@ -64,6 +65,9 @@ public class UnarchiveCommand extends Command {
         if (AddressBookParser.getInspect()) {
             return handleDeliveryUnarchive(model);
         } else {
+            if (InspectWindow.getInspectedPerson().getRole().getValue().equals("employee")) {
+                throw new CommandException(MESSAGE_CANNOT_UNARCHIVE_FOR_EMPLOYEE);
+            }
             return handlePersonUnarchive(model);
         }
     }
@@ -78,7 +82,7 @@ public class UnarchiveCommand extends Command {
     private CommandResult handleDeliveryUnarchive(Model model) throws CommandException {
         requireNonNull(model);
         Person inspectedPerson = InspectWindow.getInspectedPerson();
-        DeliveryList deliveryList = inspectedPerson.getDeliveryList();
+        List<Delivery> deliveryList = model.getFilteredDeliveryList();
         validateIndexes(inspectedPerson.getDeliveryListSize(), indexList, true);
 
         List<Delivery> deliveryToArchiveList = unarchiveDeliveries(inspectedPerson, deliveryList);
@@ -118,14 +122,13 @@ public class UnarchiveCommand extends Command {
      * @param deliveryList The list of deliveries to archive from.
      * @return A list of deliveries that were archived.
      */
-    private List<Delivery> unarchiveDeliveries(Person inspectedPerson, DeliveryList deliveryList) {
+    private List<Delivery> unarchiveDeliveries(Person inspectedPerson, List<Delivery> deliveryList) {
         List<Delivery> deliveryToUnarchiveList = new ArrayList<>();
         for (Index targetIndex : indexList) {
-            Delivery deliveryToUnarchive = deliveryList.asUnmodifiableObservableList().get(targetIndex.getZeroBased());
+            Delivery deliveryToUnarchive = deliveryList.get(targetIndex.getZeroBased());
             Delivery unarchivedDelivery = createUnarchivedDelivery(deliveryToUnarchive);
-            if (deliveryToUnarchive.isArchived()) {
-                inspectedPerson.unarchiveDelivery(targetIndex, unarchivedDelivery);
-            }
+            inspectedPerson.deleteDelivery(deliveryToUnarchive);
+            inspectedPerson.unarchiveDelivery(unarchivedDelivery);
             deliveryToUnarchiveList.add(unarchivedDelivery);
         }
         Collections.reverse(deliveryToUnarchiveList);

--- a/src/main/java/seedu/address/model/delivery/DeliveryList.java
+++ b/src/main/java/seedu/address/model/delivery/DeliveryList.java
@@ -50,6 +50,7 @@ public class DeliveryList {
     public void add(Index targetIndex, Delivery toAdd) {
         requireAllNonNull(toAdd, targetIndex);
         int index = targetIndex.getZeroBased();
+        System.out.println(index);
         internalList.add(index, toAdd);
     }
 
@@ -61,6 +62,7 @@ public class DeliveryList {
             Delivery delivery = internalList.get(i);
             if (delivery.isArchived()) {
                 Index firstArchivedIndex = Index.fromZeroBased(i);
+
                 return firstArchivedIndex;
             }
         }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -40,7 +40,6 @@ public class Person {
     private final DeliveryList deliveryList = new DeliveryList();
     private final Archive archive;
     private final Date date; // Date and time are used for sorting purposes only.
-
     private final Time time;
 
 
@@ -153,10 +152,10 @@ public class Person {
     }
 
     /**
-     * Remove the delivery from the delivery list of this person.
+     * Removes the specified delivery from the delivery list of this person based on index.
      */
-    public void deleteDelivery(Index deliveryIndex) {
-        deliveryList.remove(deliveryIndex);
+    public void deleteDelivery(Delivery delivery) {
+        deliveryList.remove(delivery);
     }
 
     /**
@@ -172,8 +171,7 @@ public class Person {
      * Add the given delivery {@code unarchivedDelivery} to the list at {@code targetIndex}.
      * {@code targetIndex} must be a valid index in the deliveryList.
      */
-    public void unarchiveDelivery(Index targetIndex, Delivery unarchivedDelivery) {
-        deleteDelivery(targetIndex);
+    public void unarchiveDelivery(Delivery unarchivedDelivery) {
         addDelivery(getFirstArchivedIndex(), unarchivedDelivery);
     }
 

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.person.exceptions.DuplicatePersonException;
@@ -24,7 +25,12 @@ import seedu.address.testutil.PersonBuilder;
 
 public class UniquePersonListTest {
 
-    private final UniquePersonList uniquePersonList = new UniquePersonList();
+    private UniquePersonList uniquePersonList;
+
+    @BeforeEach
+    public void setup() {
+        uniquePersonList = new UniquePersonList();
+    }
 
     @Test
     public void contains_nullPerson_throwsNullPointerException() {


### PR DESCRIPTION
Important behaviour changes:
- Edit, Archive, Unarchive commands are now disabled in employee inspect window(because this will lead to an ungodly amount of other bugs, probably need to document this in UG)
- After using finddel and the list of deliveries shown changes, edit, delete, archive, unarchive now properly work on the delivery referenced using the index
